### PR TITLE
Do not allow zero local reachability density in LocalOutlierFactor

### DIFF
--- a/src/AnomalyDetectors/LocalOutlierFactor.php
+++ b/src/AnomalyDetectors/LocalOutlierFactor.php
@@ -287,7 +287,7 @@ class LocalOutlierFactor implements Estimator, Learner, Scoring, Persistable
     {
         [$samples, $indices, $distances] = $this->tree->nearest($sample, $this->k);
 
-        $lrd = $this->localReachabilityDensity($indices, $distances);
+        $lrd = $this->localReachabilityDensity($indices, $distances) ?: EPSILON;
 
         $ratios = [];
 


### PR DESCRIPTION
See https://github.com/RubixML/ML/issues/334

Sometimes we get an infinite k-distance which causes a zero local reachability density and a division by zero.